### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/173/973/421173973.geojson
+++ b/data/421/173/973/421173973.geojson
@@ -286,6 +286,9 @@
     },
     "wof:country":"XS",
     "wof:created":1459009012,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"eaf53d77492cd455e1fd734aee469785",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         }
     ],
     "wof:id":421173973,
-    "wof:lastmodified":1566653125,
+    "wof:lastmodified":1582312428,
     "wof:name":"Ceerigaabo",
     "wof:parent_id":1108757789,
     "wof:placetype":"locality",

--- a/data/421/176/583/421176583.geojson
+++ b/data/421/176/583/421176583.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"XS",
     "wof:created":1459009112,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c2e1fbad48bbf6fc12aa62fec9f3d09",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566653126,
+    "wof:lastmodified":1582312428,
     "wof:name":"Woqooyi Galbeed",
     "wof:parent_id":85632733,
     "wof:placetype":"region",

--- a/data/421/181/455/421181455.geojson
+++ b/data/421/181/455/421181455.geojson
@@ -413,6 +413,9 @@
     },
     "wof:country":"XS",
     "wof:created":1459009296,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a813006a4e4db4143015c80a847b2493",
     "wof:hierarchy":[
         {
@@ -424,7 +427,7 @@
         }
     ],
     "wof:id":421181455,
-    "wof:lastmodified":1566653125,
+    "wof:lastmodified":1582312428,
     "wof:name":"Hargeysa",
     "wof:parent_id":1108757849,
     "wof:placetype":"locality",

--- a/data/421/194/355/421194355.geojson
+++ b/data/421/194/355/421194355.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"XS",
     "wof:created":1459009803,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33c67be6b99faa405fa38468b2ccacf3",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566653124,
+    "wof:lastmodified":1582312428,
     "wof:name":"Togdheer",
     "wof:parent_id":85632733,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.