### PR TITLE
xs concordances, placetype local, and more

### DIFF
--- a/data/110/875/778/9/1108757789.geojson
+++ b/data/110/875/778/9/1108757789.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"SO.SA.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308110,
     "wof:geomhash":"2c23f23bfe42df2c0e03191492afa536",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108757789,
-    "wof:lastmodified":1694498095,
+    "wof:lastmodified":1695886542,
     "wof:name":"Ceerigaabo",
     "wof:parent_id":1108805621,
     "wof:placetype":"county",

--- a/data/110/875/779/3/1108757793.geojson
+++ b/data/110/875/779/3/1108757793.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.SA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308112,
     "wof:geomhash":"497efebbf481ea4b01bfa76193455823",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757793,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886328,
     "wof:name":"Laasqoray",
     "wof:parent_id":1108805621,
     "wof:placetype":"county",

--- a/data/110/875/781/1/1108757811.geojson
+++ b/data/110/875/781/1/1108757811.geojson
@@ -176,6 +176,7 @@
     "wof:concordances":{
         "hasc:id":"SO.WO.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308122,
     "wof:geomhash":"aa62e5348e89acf027cb14ff04f5d949",
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1108757811,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886443,
     "wof:name":"Berbera",
     "wof:parent_id":421176583,
     "wof:placetype":"county",

--- a/data/110/875/781/3/1108757813.geojson
+++ b/data/110/875/781/3/1108757813.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"SO.TO.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308123,
     "wof:geomhash":"885f79db4fd2870bea19d6fefc7ecefe",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108757813,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886543,
     "wof:name":"Burco",
     "wof:parent_id":421194355,
     "wof:placetype":"county",

--- a/data/110/875/781/9/1108757819.geojson
+++ b/data/110/875/781/9/1108757819.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.SA.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308125,
     "wof:geomhash":"720283712171540e7df890da1f7367f3",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757819,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886274,
     "wof:name":"Ceel Afweyn",
     "wof:parent_id":1108805621,
     "wof:placetype":"county",

--- a/data/110/875/784/3/1108757843.geojson
+++ b/data/110/875/784/3/1108757843.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"SO.TO.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308138,
     "wof:geomhash":"69334f0b87c1c33ec01533cd133665cf",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108757843,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886442,
     "wof:name":"Buuhoodle",
     "wof:parent_id":421194355,
     "wof:placetype":"county",

--- a/data/110/875/784/7/1108757847.geojson
+++ b/data/110/875/784/7/1108757847.geojson
@@ -95,6 +95,7 @@
     "wof:concordances":{
         "hasc:id":"SO.AW.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308140,
     "wof:geomhash":"7aa833afec0c0570f33f1d711faa9511",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108757847,
-    "wof:lastmodified":1694497843,
+    "wof:lastmodified":1695886442,
     "wof:name":"Baki",
     "wof:parent_id":1108805623,
     "wof:placetype":"county",

--- a/data/110/875/784/9/1108757849.geojson
+++ b/data/110/875/784/9/1108757849.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.WO.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308141,
     "wof:geomhash":"2a49a82c1d91d90f1b0325346abbfdc2",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757849,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886302,
     "wof:name":"Hargeysa",
     "wof:parent_id":421176583,
     "wof:placetype":"county",

--- a/data/110/875/786/7/1108757867.geojson
+++ b/data/110/875/786/7/1108757867.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.SO.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308151,
     "wof:geomhash":"3c8667e0b98a5765d461c00d06e67a57",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757867,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886327,
     "wof:name":"Laas Caanood",
     "wof:parent_id":1108805619,
     "wof:placetype":"county",

--- a/data/110/875/786/9/1108757869.geojson
+++ b/data/110/875/786/9/1108757869.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.SO.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308152,
     "wof:geomhash":"5a4b615100c0c47100cc5f7446a66810",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757869,
-    "wof:lastmodified":1694498071,
+    "wof:lastmodified":1695886274,
     "wof:name":"Caynabo",
     "wof:parent_id":1108805619,
     "wof:placetype":"county",

--- a/data/110/875/787/3/1108757873.geojson
+++ b/data/110/875/787/3/1108757873.geojson
@@ -122,6 +122,7 @@
     "wof:concordances":{
         "hasc:id":"SO.AW.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308153,
     "wof:geomhash":"641fc5acefee4a2056d58b4ded703bfb",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108757873,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886443,
     "wof:name":"Borama",
     "wof:parent_id":1108805623,
     "wof:placetype":"county",

--- a/data/110/875/787/5/1108757875.geojson
+++ b/data/110/875/787/5/1108757875.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.AW.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308154,
     "wof:geomhash":"2db71280b157f70f58b06188aead5629",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757875,
-    "wof:lastmodified":1694498073,
+    "wof:lastmodified":1695886340,
     "wof:name":"Lughaye",
     "wof:parent_id":1108805623,
     "wof:placetype":"county",

--- a/data/110/875/787/7/1108757877.geojson
+++ b/data/110/875/787/7/1108757877.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.TO.OD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308155,
     "wof:geomhash":"5e4dd33157cbc22f741135a942fa2ce0",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757877,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886373,
     "wof:name":"Owdweyne",
     "wof:parent_id":421194355,
     "wof:placetype":"county",

--- a/data/110/875/789/5/1108757895.geojson
+++ b/data/110/875/789/5/1108757895.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.SO.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308166,
     "wof:geomhash":"6d1db784a4bfcb2f2e116737cb1c85b4",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757895,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886409,
     "wof:name":"Taleex",
     "wof:parent_id":1108805619,
     "wof:placetype":"county",

--- a/data/110/875/790/5/1108757905.geojson
+++ b/data/110/875/790/5/1108757905.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.NU.XU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308173,
     "wof:geomhash":"f44dff5179f6074d37b000312ce14279",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757905,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886428,
     "wof:name":"Xudun",
     "wof:parent_id":1108805619,
     "wof:placetype":"county",

--- a/data/110/875/791/5/1108757915.geojson
+++ b/data/110/875/791/5/1108757915.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.AW.ZE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308177,
     "wof:geomhash":"b5c1ade78c15c938252b65f96e6e92f9",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757915,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886433,
     "wof:name":"Zeylac",
     "wof:parent_id":1108805623,
     "wof:placetype":"county",

--- a/data/110/875/791/7/1108757917.geojson
+++ b/data/110/875/791/7/1108757917.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"SO.WO.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308178,
     "wof:geomhash":"58214e1ef0cf41da1653fcadd7c28c87",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108757917,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886294,
     "wof:name":"Gebiley",
     "wof:parent_id":421176583,
     "wof:placetype":"county",

--- a/data/110/875/793/5/1108757935.geojson
+++ b/data/110/875/793/5/1108757935.geojson
@@ -215,6 +215,7 @@
     "wof:concordances":{
         "hasc:id":"SO.TO.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"XS",
     "wof:created":1481308190,
     "wof:geomhash":"ec927df880a63c4b3025447326c32723",
@@ -227,7 +228,7 @@
         }
     ],
     "wof:id":1108757935,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886442,
     "wof:name":"Sheikh",
     "wof:parent_id":421194355,
     "wof:placetype":"county",

--- a/data/110/880/561/9/1108805619.geojson
+++ b/data/110/880/561/9/1108805619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.069775,
-    "geom:area_square_m":37493720094.44474,
+    "geom:area_square_m":37493720094.443848,
     "geom:bbox":"46.0510424368,8.00130440513,49.0809768942,10.0438936308",
     "geom:latitude":8.964121,
     "geom:longitude":47.565065,
@@ -116,11 +116,13 @@
     "wof:concordances":{
         "fips:code":"SO22",
         "hasc:id":"SO.SO",
+        "iso:code":"SO-SO",
         "iso:id":"SO-SO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XS",
     "wof:created":1485559165,
-    "wof:geomhash":"cd03b788c706a57b7898a75bdcb69dec",
+    "wof:geomhash":"11a1dd90170d68af1c78a955a45b8a5a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +139,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566653119,
+    "wof:lastmodified":1695884327,
     "wof:name":"Sool",
     "wof:parent_id":85632733,
     "wof:placetype":"region",

--- a/data/110/880/562/1/1108805621.geojson
+++ b/data/110/880/562/1/1108805621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.450137,
-    "geom:area_square_m":54137223248.327805,
+    "geom:area_square_m":54137223248.328102,
     "geom:bbox":"46.0096976484,9.42123184901,49.0608500982,11.328722",
     "geom:latitude":10.306406,
     "geom:longitude":47.682953,
@@ -131,11 +131,13 @@
     "wof:concordances":{
         "fips:code":"SO12",
         "hasc:id":"SO.SA",
+        "iso:code":"SO-SA",
         "iso:id":"SO-SA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XS",
     "wof:created":1485559168,
-    "wof:geomhash":"02f533fc31cc66b4222b09a04a7023ef",
+    "wof:geomhash":"9866dabafaf82a88226d006d689cbbd1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +154,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566653120,
+    "wof:lastmodified":1695884327,
     "wof:name":"Sanaag",
     "wof:parent_id":85632733,
     "wof:placetype":"region",

--- a/data/110/880/562/3/1108805623.geojson
+++ b/data/110/880/562/3/1108805623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.313357,
-    "geom:area_square_m":15963760559.352753,
+    "geom:area_square_m":15963760559.352913,
     "geom:bbox":"42.67008,9.6653858161,44.2394484533,11.477944374",
     "geom:latitude":10.575268,
     "geom:longitude":43.377599,
@@ -140,11 +140,13 @@
     "wof:concordances":{
         "fips:code":"SO21",
         "hasc:id":"SO.AW",
+        "iso:code":"SO-AW",
         "iso:id":"SO-AW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XS",
     "wof:created":1485559169,
-    "wof:geomhash":"067f2cad9b3e4ad9cddab817a1c1018b",
+    "wof:geomhash":"b1b4ed91f1a5b40af2fccb7c6091f62d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +163,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1566653120,
+    "wof:lastmodified":1695884328,
     "wof:name":"Awdal",
     "wof:parent_id":85632733,
     "wof:placetype":"region",

--- a/data/421/176/583/421176583.geojson
+++ b/data/421/176/583/421176583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.32164,
-    "geom:area_square_m":28281153111.790874,
+    "geom:area_square_m":28281153284.660679,
     "geom:bbox":"43.286203,8.77563,46.034014,10.867888",
     "geom:latitude":9.876132,
     "geom:longitude":44.552979,
@@ -199,17 +199,19 @@
         "gn:id":50360,
         "gp:id":2347021,
         "hasc:id":"SO.WO",
+        "iso:code":"SO-WO",
         "iso:id":"SO-WO",
         "qs_pg:id":1047416,
         "wd:id":"Q877021",
         "wk:page":"Woqooyi Galbeed"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XS",
     "wof:created":1459009112,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9300462d5e33545a6bd7150d72a257fd",
+    "wof:geomhash":"95892be3dbad71531f374ff999ef9995",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -226,7 +228,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690921866,
+    "wof:lastmodified":1695884330,
     "wof:name":"Woqooyi Galbeed",
     "wof:parent_id":85632733,
     "wof:placetype":"region",

--- a/data/421/194/355/421194355.geojson
+++ b/data/421/194/355/421194355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.81019,
-    "geom:area_square_m":34308814975.400311,
+    "geom:area_square_m":34308816089.381458,
     "geom:bbox":"44.687108,8.001139,47.100481,10.171713",
     "geom:latitude":9.109245,
     "geom:longitude":45.726861,
@@ -187,17 +187,19 @@
         "gn:id":51230,
         "gp:id":2347020,
         "hasc:id":"SO.TO",
+        "iso:code":"SO-TO",
         "iso:id":"SO-TO",
         "qs_pg:id":1047417,
         "wd:id":"Q865590",
         "wk:page":"Togdheer"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XS",
     "wof:created":1459009803,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab7787a96520afd04369ad2a346445c2",
+    "wof:geomhash":"d45e1d09f58edd5c8e213d0854574451",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -214,7 +216,7 @@
         "som",
         "ara"
     ],
-    "wof:lastmodified":1690921863,
+    "wof:lastmodified":1695884331,
     "wof:name":"Togdheer",
     "wof:parent_id":85632733,
     "wof:placetype":"region",

--- a/data/856/327/33/85632733.geojson
+++ b/data/856/327/33/85632733.geojson
@@ -725,7 +725,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1694639491,
+    "wof:lastmodified":1695881145,
     "wof:name":"Somaliland",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.